### PR TITLE
Configurable OAUTH2 client credentials

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,11 @@
 Asterisk OAUTH2.0 connection with Google Voice
 ===================
 
-
-Upgrade Asterisk to an OAUTH2.0 connection with Google Voice
+Upgrade Asterisk to an OAUTH2.0 connection with Google Voice.
 
 The project is a modification of res_xmpp written by  Matt O'Gorman and Joshua Colp.
 
-More information about using Google Voice with Asterisk can be found here 
+More information about using Google Voice with Asterisk can be found here: 
 https://wiki.asterisk.org/wiki/display/AST/Calling+using+Google
 
 If you would like to get involved or need support visit http://www.gvsip.org 
@@ -16,11 +15,15 @@ If you would like to get involved or need support visit http://www.gvsip.org
 Here is how it works
 -------------
 
-The modified version of res_xmpp allows Asterisk to connect via OAUTH2.0 instead of using a plain password.  It also allows Asterisk to obtain updated login credentials directly from Google when the server is disconnected or at start.  Asterisk obtains updated credentials (which Google expires every hour) by using an offline refresh token it obtains for free from http://www.GVsip.com .   This refresh token never changes and only needs to be obtained once.  
+The modified version of res_xmpp allows Asterisk to connect via OAUTH2.0 instead of using a plain password.  
+It also allows Asterisk to obtain updated login credentials directly from Google when the server is disconnected 
+or at start. Asterisk obtains updated credentials (which Google expires every hour) by using an offline refresh 
+token it obtains for free from http://www.GVsip.com .   This refresh token never changes and only needs to be
+obtained once. 
 
  **Primitive Installation Tutorial for Asterisk:**
 > 
-To install the modification you need to be installing asterisk from source.  (So far this has been verified to work with Asterisk 12 and 13.)
+To install the modification you need to be installing Asterisk from source.  (So far this has been verified to work with Asterisk 12 and 13.)
 
 > - Go to http://www.GVsip.com and create an account
 > - Then navigate to (Portal Menu) -> Google Voice-> Advanced Google OAUTH2.0 Manager (top right part of screen)
@@ -30,7 +33,8 @@ To install the modification you need to be installing asterisk from source.  (So
 > - Repeat as necessary for all of your Google Voice Accounts 
 > - Then modify your asterisk configuration /etc/asterisk/xmpp.conf 
 Instead of using secret=(password) comment that out and insert 
-refresh_token=(token obtained from GVsip.com)
+refresh_token=(token obtained from GVsip.com). Use the client_id and client_secret lines shown below for the
+GVsip.com service.
 
 So it should look something like this for each of your Google Accounts:
 

--- a/readme.md
+++ b/readme.md
@@ -20,49 +20,41 @@ The modified version of res_xmpp allows Asterisk to connect via OAUTH2.0 instead
 
  **Primitive Installation Tutorial for Asterisk:**
 > 
-To install the modification you need to be installing asterisk from source.  (So far this has been verified to work with Asterisk 12.)
+To install the modification you need to be installing asterisk from source.  (So far this has been verified to work with Asterisk 12 and 13.)
 
 > - Go to http://www.GVsip.com and create an account
 > - Then navigate to (Portal Menu) -> Google Voice-> Advanced Google OAUTH2.0 Manager (top right part of screen)
-> - Then click “Add Google Voice Account” (Green Button)
-> - Select an account with Google Voice and on the next screen click “accept”.
+> - Then click â€œAdd Google Voice Accountâ€ (Green Button)
+> - Select an account with Google Voice and on the next screen click â€œacceptâ€.
 > - The username and refresh_token will now be displayed on the next screen.  
 > - Repeat as necessary for all of your Google Voice Accounts 
 > - Then modify your asterisk configuration /etc/asterisk/xmpp.conf 
-Instead of using secret=(password) comment that out an insert 
+Instead of using secret=(password) comment that out and insert 
 refresh_token=(token obtained from GVsip.com)
 
-So it should look something like this for each of your Google Accounts
->[google]
+So it should look something like this for each of your Google Accounts:
 
->type=client
-
->serverhost=talk.google.com
-
->username=(username obtained from)
-
->;secret=(your plain text password)
-
->refresh_token=(token obtained from GVsip.com)
-
->priority=25
-
->port=5222
-
->usetls=yes
-
->usesasl=yes
-
->status=available
-
->statusmessage="I am using OAUTH2.0 now! Woot!"
-
->timeout=5
-
+    [google]
+    type=client
+    serverhost=talk.google.com
+    username=(your GV username@domain)
+    ;secret=(your plain text password)
+    refresh_token=(token obtained from GVsip.com)
+    client_id=470306186573-jtdetm9fb2b28k4gumaleamea7a14deh.apps.googleusercontent.com
+    ; replace client_id with your own Google OAUTH2 client ID if not using GVsip.com
+    client_secret=zWK1W_I-4ZlfRoFnYRoGhsrB
+    ; replace client_secret with your own Google OAUTH2 client secret if not using GVsip.com
+    priority=25
+    port=5222
+    usetls=yes
+    usesasl=yes
+    status=available
+    statusmessage="I am using OAUTH2.0 now! Woot!"
+    timeout=5
 
  **To complete the installation:**
 > - Download the modified version of res_xmpp.c from Github.  https://github.com/gvsip/Asterisk
 > - Copy the modified version of res_xmpp.c to
  /(asterisk source directory)/res/res_xmpp.c
-> - Then run “Make install”
+> - Then run â€œMake installâ€
 > - Then restart asterisk


### PR DESCRIPTION
This is one way of making the module more generally useful outside of gvsip.com. The client_id and client_secret are required parameters in the config and we document the gvsip.com values so that users can easily configure for your service or use their own set of id/secret/refresh_token.

Another way would be to bake the gvsip.com id/secret into the code as you had done before, as default, but if the user specifies his own set of client_id and client_secret, those would be used instead. 
